### PR TITLE
CPT support

### DIFF
--- a/amber/amber-install.php
+++ b/amber/amber-install.php
@@ -66,6 +66,7 @@ class AmberInstall {
 		if (empty($options)) {	
 			/* Set default options */
 			$options =  array(
+				'amber_post_types' => 'post,page',
 	            'amber_max_file' => 1000,
 	            'amber_max_disk' => 1000,
 	            'amber_available_action' => AMBER_ACTION_NONE,

--- a/amber/amber-settings.php
+++ b/amber/amber-settings.php
@@ -238,7 +238,6 @@ class AmberSettingsPage
         }
 
         $valid_string_options = array(
-            'amber_post_types',
             'amber_storage_location',
             'amber_excluded_formats',
             'amber_country_id'
@@ -247,6 +246,12 @@ class AmberSettingsPage
             if( isset( $input[$opt] ) )
                 $new_input[$opt] = sanitize_text_field( $input[$opt] );
         }
+
+
+        /* Process selected post types */
+        $crawled_post_types = $input['amber_post_types'];
+        $stringified_post_types = implode(',', $crawled_post_types);
+        $new_input['amber_post_types'] = $stringified_post_types;
 
         /* Validate excluded sites regular expressions */
         $excluded_sites = explode( ',' , $input['amber_excluded_sites'] );
@@ -318,11 +323,29 @@ jQuery(document).ready(function($) {
      */
     public function amber_post_types_callback()
     {
-        printf(
-            '<input type="text" id="amber_max_file" name="amber_options[amber_post_types]" value="%s" /> ' .
-            '<p class="description">Post types to scan, besides post and page.</p>',
-            isset( $this->options['amber_post_types'] ) ? esc_attr( $this->options['amber_post_types']) : ''
-        );
+        $amber_post_types_args = array(
+           'public'   => true
+        );        
+        $output = 'objects';
+        $operator = 'and';
+        $post_types = get_post_types( $args, $output, $operator ); 
+
+        $crawled_post_types = explode(',',$this->options['amber_post_types']);
+        $ignored_post_types = array('revision');
+
+        printf('<select id="amber_post_types" name="amber_options[amber_post_types][]" multiple="1" size="5">' . PHP_EOL);
+        foreach ( $post_types  as $post_type ) {
+
+            if(in_array( $post_type->name, $ignored_post_types )) {
+                continue;
+            } elseif (in_array($post_type->name, $crawled_post_types)) {
+                echo '<option value="'. $post_type->name .'" selected="1">' . $post_type->label . '</option>' . PHP_EOL;
+            } else {
+                echo '<option value="'. $post_type->name .'">' . $post_type->label . '</option>' . PHP_EOL;
+            }         
+        }
+        printf('</select>' . PHP_EOL);
+
     }
 
     public function amber_max_file_callback()

--- a/amber/amber-settings.php
+++ b/amber/amber-settings.php
@@ -66,6 +66,15 @@ class AmberSettingsPage
         );  
 
         add_settings_field(
+            'amber_post_types', 
+            'Included post types', 
+            array( $this, 'amber_post_types_callback' ), 
+            'amber-settings-admin', 
+            'amber_cache_section'          
+        );      
+
+
+        add_settings_field(
             'amber_max_file', 
             'Maximum file size (kB)', 
             array( $this, 'amber_max_file_callback' ), 
@@ -229,6 +238,7 @@ class AmberSettingsPage
         }
 
         $valid_string_options = array(
+            'amber_post_types',
             'amber_storage_location',
             'amber_excluded_formats',
             'amber_country_id'
@@ -306,6 +316,15 @@ jQuery(document).ready(function($) {
     /** 
      * Get the settings option array and print one of its values
      */
+    public function amber_post_types_callback()
+    {
+        printf(
+            '<input type="text" id="amber_max_file" name="amber_options[amber_post_types]" value="%s" /> ' .
+            '<p class="description">Post types to scan, besides post and page.</p>',
+            isset( $this->options['amber_post_types'] ) ? esc_attr( $this->options['amber_post_types']) : ''
+        );
+    }
+
     public function amber_max_file_callback()
     {
         printf(

--- a/amber/amber.php
+++ b/amber/amber.php
@@ -658,7 +658,7 @@ EOF;
 		check_ajax_referer( 'amber_dashboard' );
 		$batch_size = 10; 
 		$number_remaining = 0;
-		$transients = array('amber_scan_pages', 'amber_scan_posts');
+		$transients = array('amber_scan_posts');
 		foreach ($transients as $t) {
 			$ids = get_transient($t);
 			if ($ids !== FALSE && is_array($ids)) {

--- a/amber/amber.php
+++ b/amber/amber.php
@@ -636,14 +636,14 @@ EOF;
 	 */
 	public static function ajax_scan_start() {
 		check_ajax_referer( 'amber_dashboard' );
+		$amber_types = explode(',',Amber::get_option('amber_post_types','post,page'));
 		$post_ids = get_posts(array(
 		    'numberposts'   => -1, // get all posts.
 		    'fields'        => 'ids', // Only get post IDs
+		    'post_type'     => $amber_types,
 		));
-		$page_ids = get_all_page_ids();
-		set_transient('amber_scan_pages', $page_ids, 24*60*60);
 		set_transient('amber_scan_posts', $post_ids, 24*60*60);
-		print count($post_ids) + count($page_ids);
+		print count($post_ids);
 		die();
 	}
 

--- a/amber/amber.php
+++ b/amber/amber.php
@@ -677,7 +677,7 @@ EOF;
 
 	public static function add_meta_boxes()
 	{
-		$screens = array( 'post', 'page' );
+		$screens = explode(',',Amber::get_option('amber_post_types','post,page'));
 		foreach ( $screens as $screen ) {
 			add_meta_box(
 				'amber_sectionid',


### PR DESCRIPTION
Relates to #6 
This adds preliminary support for scanning custom post types in addition to a default of pages and posts. It's working for me, and I'm not introducing anything particularly new so much as doing some consolidating/generalizing, but I *am* kind of learning as I go, so standard disclaimers apply.