### PR TITLE
Add error message if the required PHP cURL extension isn't installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Whether links fail because of DDoS attacks, censorship, or just plain old link r
 ## System Requirements ##
 
 * WordPress 4.0 or higher
+* PHP cURL extension enabled
 
 ## Installation ##
 

--- a/amber/amber.php
+++ b/amber/amber.php
@@ -911,6 +911,14 @@ jQuery(document).ready(function($) {
 	Enable Permalinks <a href="'. get_site_url() . '/wp-admin/options-permalink.php">here</a></p>
 </div>';
 		}	
+		
+		if (!function_exists('curl_init')) {
+			print '
+<div class="error">
+	<p>The PHP cURL extension must be installed for Amber to work properly. Ask your web host to install it, or follow the instructions <a href="https://secure.php.net/manual/en/curl.installation.php" target="_blank">here</a>.</p>
+</div>';
+		}
+		
 	}
  
  	public static function ajax_log_cache_view() {


### PR DESCRIPTION
Currently the Amber WordPress plugin silently fails to create snapshots if the PHP cURL extension isn't installed, showing all links in the Amber Dashboard with a "Down" status. The error log shows: `PHP message: .../amberlink/libraries/AmberNetworkUtils.php:AmberNetworkUtils::open_multi_url:CURL not installed`. This can be difficult for an end user to research and debug, and installing the cURL extension resolves the issue.

This pull request adds a check to see if the cURL extension is installed, and throws an error message if it is not, in a manner consistent with the permalink error messages currently in use in the plugin. Additionally, it updates the README to reflect the PHP cURL extension requirement.

<img width="857" alt="screenshot 2016-01-30 at 01 52 55" src="https://cloud.githubusercontent.com/assets/166752/12694513/3024087c-c6f6-11e5-9a65-7508639982bb.png">

