### PR TITLE
Add filters to modify the cached URLs

### DIFF
--- a/amber.php
+++ b/amber.php
@@ -324,8 +324,15 @@ class Amber {
 	 * Lookup a URL using the AmberStorage class, while caching for the duration of the page load
 	 */
 	private static function lookup_url($url) {
+	  $attributes = array();
 	  $status = Amber::get_status();
-	  return Amber::build_link_attributes($status->get_summary($url, array(Amber::get_option('amber_backend', 0))));
+	  $url = apply_filters('amber_lookup_url', $url);
+
+	  if (!empty($url)) {
+	    $attributes = Amber::build_link_attributes($status->get_summary($url, array(Amber::get_option('amber_backend', 0))));
+	  }
+
+	  return $attributes;
 	}
 
 	/**
@@ -420,6 +427,11 @@ class Amber {
 	}
 
 	private static function cache_link($item, $force = false) {
+		$item = apply_filters('amber_cache_link', item);
+
+		if (empty($link)) {
+			return false;
+		}
 
 		$checker = Amber::get_checker();
 		$status =  Amber::get_status();


### PR DESCRIPTION
This is PR is part of a fix for #44. It adds two filters to the amber link caching process. One during the enqueue process and another during the lookup. This lets us edit links before Amber tries to cache them. We then modify those links again when Amber looks them up.

Here's an example of the use of these filters to fix the issue in #44:

```php
function remove_twitter_url_query_string($url) {
	return preg_replace('/(https?:\/\/twitter\.com[^?]*).*/i', '$1', $url);
}
add_filter('amber_cache_link', 'remove_twitter_url_query_string');
add_filter('amber_lookup_url', 'remove_twitter_url_query_string');
```