### PR TITLE
Fix broken AJAX URLs

### DIFF
--- a/amber.php
+++ b/amber.php
@@ -649,9 +649,6 @@ class Amber {
 		add_rewrite_rule('^.*amber/cache/([a-f0-9]+)/?$', '/index.php?amber_cache=$1', "top");
 		add_rewrite_rule('^.*amber/cacheframe/([a-f0-9]+)/?$', '/index.php?amber_cacheframe=$1', "top");
 		add_rewrite_rule('^.*amber/cacheframe/([a-f0-9]+)/assets/(.*)/?$', '/index.php?amber_cacheframe=$1&amber_asset=$2', "top");
-		add_rewrite_rule('^.*amber/logcacheview?(.*)/?$', '/wp-admin/admin-ajax.php?action=amber_logcacheview&$1', "top");
-		add_rewrite_rule('^.*amber/status?(.*)/?$', '/wp-admin/admin-ajax.php?action=amber_status&$1', "top");
-		add_rewrite_rule('^.*amber/memento?(.*)/?$', '/wp-admin/admin-ajax.php?action=amber_memento&$1', "top");
 	}
 
 	/**
@@ -1141,6 +1138,7 @@ add_action( 'wp_ajax_amber_cache_now', array('Amber', 'ajax_cache_now') );
 add_action( 'wp_ajax_amber_scan_start', array('Amber', 'ajax_scan_start') );
 add_action( 'wp_ajax_amber_scan', array('Amber', 'ajax_scan') );
 add_action( 'wp_ajax_nopriv_amber_logcacheview', array('Amber', 'ajax_log_cache_view') );
+add_action( 'wp_ajax_amber_logcacheview', array('Amber', 'ajax_log_cache_view') );
 add_action( 'wp_ajax_nopriv_amber_status', array('Amber', 'ajax_get_url_status') );
 add_action( 'wp_ajax_amber_status', array('Amber', 'ajax_get_url_status') );
 add_action( 'wp_ajax_nopriv_amber_memento', array('Amber', 'ajax_get_memento') );

--- a/js/amber.js
+++ b/js/amber.js
@@ -373,7 +373,7 @@ var amber = {
         };
         // Send synchronous notification, to ensure it's sent completely before the page unloads
         // This would be a good place to use navigator.sendBeacon(), once it has more support
-        request.open('GET', '/amber/logcacheview?cache=' + href + '&t=' + new Date().getTime(), false);
+        request.open('GET', ajaxurl + '?action=amber_logcacheview&cache=' + href + '&t=' + new Date().getTime(), false);
         request.send();
       });
     });
@@ -440,7 +440,7 @@ var amber = {
       params += "&country=" + amber.country;
 
       request = new XMLHttpRequest();
-      request.open('POST', "/amber/status");
+      request.open('POST', ajaxurl + '?action=amber_status');
       request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
       request.onload = function() {
         if (request.readyState === 4) {
@@ -462,7 +462,7 @@ var amber = {
         callback(JSON.parse(request.responseText));
       }
     };
-    request.open('GET', '/amber/memento?date=' + date + '&url=' + href);
+    request.open('GET', ajaxurl + '?action=amber_memento&date=' + date + '&url=' + href);
     request.send();
   },
 


### PR DESCRIPTION
This is a fix for an issue with the rewrite rules for `admin-ajax.php`. You cannot create rewrite rules this way as this isn't how rewrite rules in WordPress work. (You can read more about it [here](https://wordpress.stackexchange.com/questions/137315/rewrite-rule-for-admin-ajax-php).) These rewrite rules might work with Apache but only because they're added to the `.htaccess` file. They won't work with nginx.

Instead, the correct way to do this is to use the `ajaxurl` variable that WordPress puts at your disposition. I've edited `amber.js` to make use of it. I've also removed the rewrite rules. There was also a missing AJAX action for `logcacheview` which I added.