### PR TITLE
Add `AMBER_LOG_ROBOTSTXT_ERRORS` constant to silence error_log for robots.txt errors

### DIFF
--- a/libraries/AmberChecker.php
+++ b/libraries/AmberChecker.php
@@ -54,7 +54,10 @@ class AmberChecker implements iAmberChecker {
       /* If blocked by robots.txt, schedule next check for 6 months out */
       $next = $date->add(new DateInterval("P6M"))->getTimestamp();
       $status = isset($last_check['status']) ? $last_check['status'] : NULL;
-      error_log(join(":", array(__FILE__, __METHOD__, "Blocked by robots.txt", $url)));
+      /*  Define `AMBER_LOG_ROBOTSTXT_ERRORS` as false to disable error logging */
+      if (!defined('AMBER_LOG_ROBOTSTXT_ERRORS') OR AMBER_LOG_ROBOTSTXT_ERRORS) {
+		    error_log(join(":", array(__FILE__, __METHOD__, "Blocked by robots.txt", $url)));
+	    }
       $message = "Blocked by robots.txt";
     } else {
       $fetch_result = AmberNetworkUtils::open_url($url,  array(CURLOPT_FAILONERROR => FALSE));


### PR DESCRIPTION
- We ended up with a lot of URLs in our queue that get blocked by robots.txt
- Having them output to error_log() makes it hard to read our logs, and offers nothing
- This adds a simple constant that can be put in wp-config or elsewhere to disable the error logging
- I'd also support just removing this error_log entirely. There are better ways we could get access to this information.